### PR TITLE
markdown-it-py 4.0.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,9 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    # UnicodeDecodeError: 'charmap' codec can't decode byte
+    - set PYTHONUTF8=1              # [win]
+    - set PYTHONIOENCODING="UTF-8"  # [win]
     - pytest -k "not({{ tests_to_skip }})" -v gh/tests
     - markdown-it --help
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,59 +1,85 @@
 {% set name = "markdown-it-py" %}
-{% set version = "2.2.0" %}
+{% set version = "4.0.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1
+  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/markdown_it_py-{{ version }}.tar.gz
+    sha256: cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3
+  - url: https://github.com/executablebooks/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: c562899de418498f223f0c48b3d462319a64493bd3b2758e1a76f11ad8f0ae15
+    folder: gh
 
 build:
-  number: 1
+  number: 0
   entry_points:
     - markdown-it = markdown_it.cli.parse:main
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<310]
 
 requirements:
   host:
     - python
     - pip
     - flit-core >=3.4,<4
-    - setuptools
-    - wheel
   run:
     - python
-    - mdurl >=0.1,<1
-    - typing_extensions >=3.7.4   # [py37]
+    - mdurl >=0.1,<0.2
+  run_constrained:
+    - commonmark >=0.9,<0.10
+    - markdown >=3.4,<3.5
+    - mistletoe >=1.0,<2.0
+    - mistune >=3.0,<4.0
+    - panflute >=2.3,<2.4
+    - linkify-it-py >=1,<3
+    - mdit-py-plugins >=0.5.0
+    - sphinx-book-theme >=1,<2
+
+# E IndexError: string index out of range
+{% set tests_to_skip = "test_commonmark_extras" %}
+# Missing pytest-regressions in the main channel
+{% set tests_to_skip = tests_to_skip + " or test_table_tokens
+                                         or test_file or test_use_existing_env
+                                         or test_store_labels
+                                         or test_inline_definitions
+                                         or test_pretty
+                                         or test_pretty_text_special" %}
 
 test:
+  source_files:
+    - gh/tests
   requires:
     - pip
+    - pytest
+    - linkify-it-py
   imports:
     - markdown_it
     - markdown_it.cli
-    - markdown_it.common
-    - markdown_it.helpers
+    - markdown_it.main
     - markdown_it.presets
-    - markdown_it.rules_block
-    - markdown_it.rules_core
+    - markdown_it.renderer
     - markdown_it.rules_inline
+    - markdown_it.token
+    - markdown_it.tree
+    - markdown_it.utils
   commands:
-    - markdown-it --help
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -k "not({{ tests_to_skip }})" -v gh/tests
+    - markdown-it --help
 
 about:
-  home: https://github.com/ExecutableBookProject/markdown-it-py
+  home: https://github.com/executablebooks/markdown-it-py
   license: MIT
   license_family: MIT
   license_file: LICENSE
   description: |
     Python port of markdown-it. Markdown parsing, done right!
   summary: Python port of markdown-it. Markdown parsing, done right!
-  doc_url: https://github.com/ExecutableBookProject/markdown-it-py/blob/master/README.md
-  dev_url: https://github.com/ExecutableBookProject/markdown-it-py
+  doc_url: https://github.com/executablebooks/markdown-it-py/blob/master/README.md
+  dev_url: https://github.com/executablebooks/markdown-it-py
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
markdown-it-py 4.0.0 

**Destination channel:** Defaults

### Links

- [PKG-9344]
- dev_url:        https://github.com/ExecutableBookProject/markdown-it-py/tree/v4.0.0
- conda_forge:    https://github.com/conda-forge/markdown-it-py-feedstock
- pypi:           https://pypi.org/project/markdown-it-py/4.0.0
- pypi inspector: https://inspector.pypi.io/project/markdown-it-py/4.0.0

### Explanation of changes:

- new version number


[PKG-9344]: https://anaconda.atlassian.net/browse/PKG-9344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ