### PR TITLE
markdown-it-py 4.0.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     folder: gh
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - markdown-it = markdown_it.cli.parse:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -33,9 +33,7 @@ requirements:
     - mdurl >=0.1,<0.2
   run_constrained:
     - commonmark >=0.9,<0.10
-    # Relax the upper bound to allow for the latest version of markdown
-    # with py314 support on the main channel.
-    - markdown >=3.4,<3.9
+    - markdown >=3.4,<4
     - mistletoe >=1.0,<2.0
     - mistune >=3.0,<4.0
     - panflute >=2.3,<2.4
@@ -87,7 +85,7 @@ about:
   description: |
     Python port of markdown-it. Markdown parsing, done right!
   summary: Python port of markdown-it. Markdown parsing, done right!
-  doc_url: https://github.com/executablebooks/markdown-it-py/blob/master/README.md
+  doc_url: https://markdown-it-py.readthedocs.io
   dev_url: https://github.com/executablebooks/markdown-it-py
 
 extra:


### PR DESCRIPTION
markdown-it-py 4.0.0 

**Destination channel:** Defaults

### Links

- [PKG-14083]
- dev_url:        https://github.com/executablebooks/markdown-it-py
- conda_forge:    None
- pypi:           https://pypi.org/project/markdown-it-py/4.0.0
- pypi inspector: https://inspector.pypi.io/project/markdown-it-py/4.0.0

### Explanation of changes:

- fix the `markdown` pinning
- new build number
- update `doc_url`


[PKG-14083]: https://anaconda.atlassian.net/browse/PKG-14083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ